### PR TITLE
added a basic docker-compose based dev environment

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+# === Raster Loader Environment Variables ===

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,22 @@ After creating your environment, you can enter the virtual environment with
 ``source env/bin/activate`` on Linux and macOS or ``env\bin\Activate.ps1`` on Windows
 (PowerShell).
 
+
+### Setting up your environment (Docker / Docker-Compose)
+
+1. Install Docker and Docker Compose on your system by following the instructions for your operating system from the official Docker website.
+2. Use `git clone` to clone [the Raster Loader repository](https://github.com/CartoDB/raster-loader)
+to your local machine.
+3. Navigate to the root directory of the repository in your terminal.
+4. Run `make docker-build` command to build the docker image
+5. Run `make docker-start` to start the development environment
+6. Run `make docker-test` to run the test suite
+7. Run `git checkout -b my-new-feature` to start a new feature branch
+8. Run `make docker-enter` to open a terminal inside of the docker container
+9. Run `make docker-stop` to stop the development environment
+
+*Note: If you want to make changes to library dependencies (i.e. requirements.txt or requirements-dev.txt) while the container is running, you'll need to rebuild the image using the make docker-build command and restart the container."*
+
 ### Tests and linting
 
 Before submitting a pull request, you need to make sure your updates pass tests and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,10 @@ to your local machine.
 5. Run `make docker-start` to start the development environment
 6. Run `make docker-test` to run the test suite
 7. Run `git checkout -b my-new-feature` to start a new feature branch
-8. Run `make docker-enter` to open a terminal inside of the docker container
-9. Run `make docker-stop` to stop the development environment
+8. Consider writing a test in `raster_loader/tests/` to guide your implementation
+9. Run `make docker-enter` to open a terminal inside of the docker container
+10. Run `make docker-stop` to stop the development environment
+11. Run `make docker-remove` to remove docker raster_loader Container/Network/Volume from your system
 
 *Note: If you want to make changes to library dependencies (i.e. requirements.txt or requirements-dev.txt) while the container is running, you'll need to rebuild the image using the make docker-build command and restart the container."*
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,13 +57,16 @@ After creating your environment, you can enter the virtual environment with
 to your local machine.
 3. Navigate to the root directory of the repository in your terminal.
 4. Run `make docker-build` command to build the docker image
-5. Run `make docker-start` to start the development environment
-6. Run `make docker-test` to run the test suite
-7. Run `git checkout -b my-new-feature` to start a new feature branch
-8. Consider writing a test in `raster_loader/tests/` to guide your implementation
-9. Run `make docker-enter` to open a terminal inside of the docker container
-10. Run `make docker-stop` to stop the development environment
-11. Run `make docker-remove` to remove docker raster_loader Container/Network/Volume from your system
+5. Run `make docker-start` to start the development environment. Keep this process running.
+6. Begin your development in a new terminal.
+7. Run `make docker-test` to run the test suite.
+8. Run a targeted test using pytest flags: `make docker-test PYTEST_FLAGS='-s -k array'`
+9. Run `git checkout -b my-new-feature` to start a new feature branch
+10. Consider writing a test in `raster_loader/tests/` to guide your implementation
+11. Drop into `pdb` when a test fails: `make docker-test PYTEST_FLAGS='-s --pdb'`
+12. Run `make docker-enter` to open a terminal inside of the docker container
+13. Run `make docker-stop` to stop the development environment
+14. Run `make docker-remove` to remove docker raster_loader Container/Network/Volume from your system
 
 *Note: If you want to make changes to library dependencies (i.e. requirements.txt or requirements-dev.txt) while the container is running, you'll need to rebuild the image using the make docker-build command and restart the container."*
 

--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,26 @@ publish-test-pypi:
 
 clean:
 	rm -rf $(VENV) $(DIST) $(BUILD) *.egg-info
+
+ENTER_CONTAINER:=docker-compose exec raster_loader
+
+.PHONY: docker-build
+docker-build: ## Build necessary stuff.
+	docker-compose build
+
+.PHONY: docker-start
+docker-start: ## Start containers with docker-compose and attach to logs.
+	docker-compose up --no-build
+
+.PHONY: docker-test
+docker-test: ## Enter the running backend container and run tests.
+	$(ENTER_CONTAINER) sh -c 'cd raster_loader && pytest $(PYTEST_FLAGS)'
+
+.PHONY: docker-enter
+docker-enter: ## Enter the backend container.
+	$(ENTER_CONTAINER) bash
+
+.PHONY: docker-stop
+docker-stop: ## Stop all running containers.
+	docker-compose stop
+

--- a/Makefile
+++ b/Makefile
@@ -60,3 +60,6 @@ docker-enter: ## Enter the backend container.
 docker-stop: ## Stop all running containers.
 	docker-compose stop
 
+.PHONY: docker-remove
+docker-remove: ## Remove all containers / volumes
+	docker-compose down --volumes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+
+services:
+  raster_loader:
+    platform: linux/amd64
+    image: carto/raster_loader
+    ports:
+      - '8888:8888'
+    build:
+      context: .
+      dockerfile: docker/raster_loader/Dockerfile
+    volumes:
+      - './:/code'
+    env_file: ./.env
+    command: |
+      sh -c 'tail -f /dev/null'

--- a/docker/raster_loader/Dockerfile
+++ b/docker/raster_loader/Dockerfile
@@ -1,0 +1,41 @@
+FROM osgeo/gdal:3.2.0
+
+ENV HOMEAPP=/code
+ENV PATH=$PATH:$HOMEAPP/.local/bin
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
+WORKDIR $HOMEAPP/
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install --no-install-recommends -y \
+    bash \
+    build-essential \
+    gcc \
+    git \
+    libpq-dev \
+    python3-dev \
+    postgresql-client \
+    wget \
+    gdal-bin \
+    python3-pip \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# Using a non-privileged user to own our code
+RUN useradd -d $HOMEAPP -N non-privileged
+
+# Update non-privileged user folder permission
+RUN chown -R non-privileged $HOMEAPP
+
+# Copy the requirements file into the container
+COPY requirements.txt .
+COPY requirements-dev.txt .
+COPY . .
+
+# Install the dependencies
+RUN pip install --upgrade pip
+RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements-dev.txt
+
+# Copy the rest of the files into the container
+USER non-privileged


### PR DESCRIPTION
## Issue
Related to #58 

## Proposed Changes
Add a `docker-compose` based docker development environment for raster_loader with associated commands in the Makefile.

This PR add the following new commands to the Makefile:
- `docker-build`:  Build necessary stuff.
- `docker-start`: Start container with docker-compose and attach to logs.
- `docker-test`: Enter the running raster_loader container and run tests.
- `docker-enter`: Enter the raster_loader container.
- `docker-stop`: Stop container

## Pull Request Checklist
- [x] I have tested the changes locally
- [x] I have added tests to cover my changes (if applicable)
- [x] I have updated the documentation (if applicable)

## Additional Information

I added the `docker-` prefix to these commands just to keep other existing commands intact, but moving forward we could switch all Makefile commands to interact with the Docker environment and drop the `docker-` prefix.
