### PR TITLE
Raise rasterio.errors.CRSError for invalid CRS and Add test error condition (#89)

### DIFF
--- a/raster_loader/io.py
+++ b/raster_loader/io.py
@@ -47,7 +47,7 @@ def batched(iterable, n):
     if n < 1:  # pragma: no cover
         raise ValueError("n must be at least one")
     it = iter(iterable)
-    while batch := tuple(islice(it, n)):
+    while batch := tuple(islice(it, n)):  # noqa
         yield batch
 
 
@@ -263,10 +263,14 @@ def rasterio_windows_to_records(
         if input_crs is None:
             input_crs = raster_crs
         elif input_crs != raster_crs:
-            print(f"WARNING: Input CRS({input_crs}) != raster CRS({raster_crs}).")
+            msg = "Input CRS conflicts with input raster metadata."
+            err = rasterio.errors.CRSError(msg)
+            raise err
 
         if not input_crs:  # pragma: no cover
-            raise ValueError("Unable to find valid input_crs.")
+            msg = "Unable to find valid input_crs."
+            err = rasterio.errors.CRSError(msg)
+            raise err
 
         transformer = pyproj.Transformer.from_crs(
             input_crs, "EPSG:4326", always_xy=True
@@ -582,6 +586,9 @@ def rasterio_to_bigquery(
 
         raise KeyboardInterrupt
 
+    except rasterio.errors.CRSError as e:
+        raise e
+
     except Exception as e:
         delete_table = ask_yes_no_question(
             (
@@ -653,4 +660,3 @@ def get_block_dims(file_path: str) -> tuple:
 
     with rasterio.open(file_path) as raster_dataset:
         return raster_dataset.block_shapes[0]
-

--- a/raster_loader/tests/mocks.py
+++ b/raster_loader/tests/mocks.py
@@ -6,9 +6,11 @@ def bigquery_client(load_error=False):
         def load_table_from_dataframe(self, *args, **kwargs):
             if load_error:  # pragma: no cover
                 raise Exception
+
             class job(object):
                 def result():
-                    return  True
-            return  job
+                    return True
+
+            return job
 
     return BigQueryClient(load_error=load_error)

--- a/raster_loader/tests/test_io.py
+++ b/raster_loader/tests/test_io.py
@@ -356,18 +356,23 @@ def test_rasterio_to_bigquery_with_one_chunk_size(*args, **kwargs):
 
 @patch("raster_loader.io.check_if_bigquery_table_exists", return_value=False)
 def test_rasterio_to_bigquery_invalid_input_crs(*args, **kwargs):
+
+    import rasterio
+
     client = mocks.bigquery_client()
     test_file = os.path.join(fixtures_dir, "mosaic.tif")
 
-    success = io.rasterio_to_bigquery(
-        test_file,
-        project_id="test",
-        dataset_id="test",
-        table_id="test",
-        client=client,
-        input_crs=3232,
-    )
-    assert success
+    # test that invalid input crs raises an error
+    invalid_crs = 8675309
+    with pytest.raises(rasterio.errors.CRSError):
+        io.rasterio_to_bigquery(
+            test_file,
+            project_id="test",
+            dataset_id="test",
+            table_id="test",
+            client=client,
+            input_crs=invalid_crs,
+        )
 
 
 @patch("raster_loader.io.check_if_bigquery_table_exists", return_value=True)


### PR DESCRIPTION
## Issue / Proposed Changes
If the user supplies an invalid CRS, or the CRS doesn't match the metadata of the raster, then the `rasterio.errors.CRSError` is thrown.

Also implemented unittest which supplies invalid CRS code and asserts the correct exception is raised.

Fixes #89 

## Pull Request Checklist

- [x] I have tested the changes locally
- [x] I have added tests to cover my changes (if applicable)