### PR TITLE
Dockerfile - avoid installing GDAL twice

### DIFF
--- a/docker/raster_loader/Dockerfile
+++ b/docker/raster_loader/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get update \
     python3-dev \
     postgresql-client \
     wget \
-    gdal-bin \
     python3-pip \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Issue

Fixes #103 

## Proposed Changes

Avoid installing GDAL twice resulting in having installed an unexpected version of GDAL.

## Pull Request Checklist

- [x] I have tested the changes locally
- [ ] I have added tests to cover my changes (if applicable)
- [ ] I have updated the documentation (if applicable)

## Additional Information

N/A
