### PR TITLE
Chore/sc 306096/add level to raster metadata

### DIFF
--- a/raster_loader/io.py
+++ b/raster_loader/io.py
@@ -595,6 +595,7 @@ def rasterio_windows_to_records(
                     window.col_off,
                     crs=input_crs,
                 )
+
             else:
                 rec = array_to_record(
                     raster_dataset.read(band, window=window),


### PR DESCRIPTION
## Issue

Fixes #
[sc-306621]

## Proposed Changes

I'm adding resolution to the field metadata only in the case we are uploading quadbins. When appending tables, any_value is taken.

## Pull Request Checklist

- [x] I have tested the changes locally
- [ ] I have added tests to cover my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
