### PR TITLE
chore: raise error when pixel resolution greater than 26

### DIFF
--- a/raster_loader/io.py
+++ b/raster_loader/io.py
@@ -166,6 +166,14 @@ def rasterio_metadata(
         block_width = a_window[1].width
         block_height = a_window[1].height
 
+        pixel_resolution = int(resolution + math.log(block_width * block_height, 4))
+        if pixel_resolution > 26:
+            raise ValueError(
+                "Input raster pixel resolution exceeds "
+                "the max supported resolution of 26.\n"
+                "Please resample the raster to a lower resolution."
+            )
+
         metadata["bands"] = [
             {"type": e["type"], "name": e["band_name"]} for e in bands_metadata
         ]
@@ -177,9 +185,7 @@ def rasterio_metadata(
         metadata["block_height"] = block_height
         metadata["num_blocks"] = int(width * height / block_width / block_height)
         metadata["num_pixels"] = width * height
-        metadata["pixel_resolution"] = int(
-            resolution + math.log(block_width * block_height, 4)
-        )
+        metadata["pixel_resolution"] = pixel_resolution
 
     return metadata
 


### PR DESCRIPTION
## Proposed Changes

Rasters with input resolution greater than 26 are not supported by the AT. In this case we raise an error.

## Pull Request Checklist

- [x] I have tested the changes locally