### PR TITLE
fix: error when bigquery dependencies not installed

### DIFF
--- a/raster_loader/errors.py
+++ b/raster_loader/errors.py
@@ -17,17 +17,6 @@ def import_error_snowflake():  # pragma: no cover
     raise ImportError(msg)
 
 
-def import_error_rasterio():  # pragma: no cover
-    msg = (
-        "Rasterio is not installed.\n"
-        "Please install rasterio to use this function.\n"
-        "See https://rasterio.readthedocs.io/en/latest/installation.html\n"
-        "for installation instructions.\n"
-        "Alternatively, run `pip install rasterio` to install from pypi."
-    )
-    raise ImportError(msg)
-
-
 def import_error_rio_cogeo():  # pragma: no cover
     msg = (
         "Rasterio is not installed.\n"

--- a/raster_loader/errors.py
+++ b/raster_loader/errors.py
@@ -9,32 +9,9 @@ def import_error_bigquery():  # pragma: no cover
 
 def import_error_snowflake():  # pragma: no cover
     msg = (
-        "Google Snowflake is not installed.\n"
+        "Snowflake is not installed.\n"
         "Please install Snowflake to use this function.\n"
-        "See https://docs.snowflake.com/en/developer-guide/python-connector\n"
         "run `pip install -U raster-loader[snowflake]` to install from pypi."
-    )
-    raise ImportError(msg)
-
-
-def import_error_rio_cogeo():  # pragma: no cover
-    msg = (
-        "Rasterio is not installed.\n"
-        "Please install rio_cogeo to use this function.\n"
-        "See https://cogeotiff.github.io/rio-cogeo/\n"
-        "for installation instructions.\n"
-        "Alternatively, run `pip install rio-cogeo` to install from pypi."
-    )
-    raise ImportError(msg)
-
-
-def import_error_quadbin():  # pragma: no cover
-    msg = (
-        "Quadbin is not installed.\n"
-        "Please install quadbin to use this function.\n"
-        "See https://github.com/CartoDB/quadbin-py\n"
-        "for installation instructions.\n"
-        "Alternatively, run `pip install quadbin` to install from pypi."
     )
     raise ImportError(msg)
 

--- a/raster_loader/errors.py
+++ b/raster_loader/errors.py
@@ -2,9 +2,7 @@ def import_error_bigquery():  # pragma: no cover
     msg = (
         "Google Cloud BigQuery is not installed.\n"
         "Please install Google Cloud BigQuery to use this function.\n"
-        "See https://googleapis.dev/python/bigquery/latest/index.html\n"
-        "for installation instructions.\n"
-        "OR, run `pip install google-cloud-bigquery` to install from pypi."
+        "run `pip install -U raster-loader[bigquery]` to install from pypi."
     )
     raise ImportError(msg)
 
@@ -14,8 +12,7 @@ def import_error_snowflake():  # pragma: no cover
         "Google Snowflake is not installed.\n"
         "Please install Snowflake to use this function.\n"
         "See https://docs.snowflake.com/en/developer-guide/python-connector\n"
-        "for installation instructions.\n"
-        "OR, run `pip install snowflake-connector-python` to install from pypi."
+        "run `pip install -U raster-loader[snowflake]` to install from pypi."
     )
     raise ImportError(msg)
 

--- a/raster_loader/errors.py
+++ b/raster_loader/errors.py
@@ -1,7 +1,7 @@
 def import_error_bigquery():  # pragma: no cover
     msg = (
-        "Google Cloud BigQuery is not installed.\n"
-        "Please install Google Cloud BigQuery to use this function.\n"
+        "Google Cloud BigQuery client is not installed.\n"
+        "Please install Google Cloud BigQuery dependencies to use this function.\n"
         "run `pip install -U raster-loader[bigquery]` to install from pypi."
     )
     raise ImportError(msg)
@@ -9,8 +9,8 @@ def import_error_bigquery():  # pragma: no cover
 
 def import_error_snowflake():  # pragma: no cover
     msg = (
-        "Snowflake is not installed.\n"
-        "Please install Snowflake to use this function.\n"
+        "Snowflake client is not installed.\n"
+        "Please install Snowflake dependencies to use this function.\n"
         "run `pip install -U raster-loader[snowflake]` to install from pypi."
     )
     raise ImportError(msg)

--- a/raster_loader/io/bigquery.py
+++ b/raster_loader/io/bigquery.py
@@ -29,17 +29,28 @@ else:
 
 from raster_loader.io.datawarehouse import DataWarehouseConnection
 
+if _has_bigquery:
 
-class AccessTokenCredentials(Credentials):
-    def __init__(self, access_token):
-        super(AccessTokenCredentials, self).__init__()
-        self._access_token = access_token
+    class AccessTokenCredentials(Credentials):
+        def __init__(self, access_token):
+            super(AccessTokenCredentials, self).__init__()
+            self._access_token = access_token
 
-    def refresh(self, request):
-        pass
+        def refresh(self, request):
+            pass
 
-    def apply(self, headers, token=None):
-        headers["Authorization"] = f"Bearer {self._access_token}"
+        def apply(self, headers, token=None):
+            headers["Authorization"] = f"Bearer {self._access_token}"
+
+else:
+
+    class Credentials:
+        def __init__(self):
+            import_error_bigquery()
+
+    class AccessTokenCredentials:
+        def __init__(self, access_token):
+            import_error_bigquery()
 
 
 class BigQueryConnection(DataWarehouseConnection):

--- a/raster_loader/io/common.py
+++ b/raster_loader/io/common.py
@@ -9,20 +9,12 @@ from typing import Callable
 from typing import List
 from typing import Tuple
 from affine import Affine
-
-try:
-    import rio_cogeo
-except ImportError:  # pragma: no cover
-    _has_rio_cogeo = False
-else:
-    _has_rio_cogeo = True
-
+import rio_cogeo
 import rasterio
 import quadbin
 
 from raster_loader.geo import raster_bounds
 from raster_loader.errors import (
-    import_error_rio_cogeo,
     error_not_google_compatible,
 )
 
@@ -99,10 +91,6 @@ def rasterio_metadata(
     bands_info: List[Tuple[int, str]],
     band_rename_function: Callable,
 ):
-    """Requires rio_cogeo."""
-    if not _has_rio_cogeo:  # pragma: no cover
-        import_error_rio_cogeo()
-
     """Open a raster file with rasterio."""
     raster_info = rio_cogeo.cog_info(file_path).dict()
 


### PR DESCRIPTION
## Issue

If raster-loader is installed without the optional bigquery dependencies if fails with uncontrolled error even if bigquery not used:

```
Traceback (most recent call last):
  File "/Users/ernesto/cartodb/rasterenv/bin/carto", line 5, in <module>
    from raster_loader.cli import main
  File "/Users/ernesto/cartodb/raster-loader/raster_loader/__init__.py", line 3, in <module>
    from raster_loader.io.bigquery import (
  File "/Users/ernesto/cartodb/raster-loader/raster_loader/io/bigquery.py", line 33, in <module>
    class AccessTokenCredentials(Credentials):
                                 ^^^^^^^^^^^
NameError: name 'Credentials' is not defined    
```

## Proposed Changes

Prevent the uncontrolled error; if bigquery is used and the depencies are not available fail with the same error message as before the bug was introduced:  

```
Google Cloud BigQuery is not installed.
Please install Google Cloud BigQuery to use this function.
See https://googleapis.dev/python/bigquery/latest/index.html
for installation instructions.
OR, run `pip install google-cloud-bigquery` to install from pypi.
```
