### PR TITLE
fix: shapely.wkt import

### DIFF
--- a/raster_loader/io/common.py
+++ b/raster_loader/io/common.py
@@ -9,6 +9,8 @@ from typing import Callable
 from typing import List
 from typing import Tuple
 from affine import Affine
+from shapely import wkt  # Can not use directly from shapely.wkt
+
 import rio_cogeo
 import rasterio
 import quadbin
@@ -132,7 +134,7 @@ def rasterio_metadata(
 
         # compute whole bounds for metadata
         bounds_geog = raster_bounds(raster_dataset, transformer, "wkt")
-        bounds_polygon = shapely.Polygon(shapely.wkt.loads(bounds_geog))
+        bounds_polygon = shapely.Polygon(wkt.loads(bounds_geog))
         bounds_coords = list(bounds_polygon.bounds)
         center_coords = list(*bounds_polygon.centroid.coords)
         center_coords.append(resolution)


### PR DESCRIPTION
## Issue

In some cases, we can not use the function `shapely.wkt.loads` importing only shapely.

```
$ python
Python 3.8.10 (default, Nov 22 2023, 10:22:35) 
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import shapely
>>> shapely.__version__
'2.0.3'
>>> shapely.wkt.loads
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'shapely' has no attribute 'wkt'
>>> from shapely import wkt
>>> wkt.loads
<function loads at 0x7fa5eb5ccc10>
```

## Proposed Changes

I've introduced a change to import `wkt` and then use `wkt.loads`.
