### PR TITLE
fix: make the gdalwarp examples consistent

### DIFF
--- a/docs/source/user_guide/cli.rst
+++ b/docs/source/user_guide/cli.rst
@@ -52,7 +52,7 @@ by converting it with the following GDAL command:
 
 .. code-block:: bash
 
-   gdalwarp -of COG -co TILING_SCHEME=GoogleMapsCompatible -co COMPRESS=DEFLATE -co OVERVIEWS=NONE -co ADD_ALPHA=NO -co RESAMPLING=NEAREST -co BLOCKSIZE=512 <input_raster>.tif <output_raster>.tif
+   gdalwarp -of COG -co TILING_SCHEME=GoogleMapsCompatible -co COMPRESS=DEFLATE -co OVERVIEWS=IGNORE_EXISTING -co ADD_ALPHA=NO -co RESAMPLING=NEAREST -co BLOCKSIZE=512 <input_raster>.tif <output_raster>.tif
 
 You have the option to also set up a table in your provider and use this table to upload
 your data to. In case you do not specify a table name, Raster Loader will automatically

--- a/docs/source/user_guide/use_with_python.rst
+++ b/docs/source/user_guide/use_with_python.rst
@@ -60,7 +60,7 @@ by converting it with the following GDAL command:
 
 .. code-block:: bash
 
-   gdalwarp -of COG -co TILING_SCHEME=GoogleMapsCompatible -co COMPRESS=DEFLATE -co OVERVIEWS=NONE -co ADD_ALPHA=NO -co RESAMPLING=NEAREST -co BLOCKSIZE=512 <input_raster>.tif <output_raster>.tif
+   gdalwarp -of COG -co TILING_SCHEME=GoogleMapsCompatible -co COMPRESS=DEFLATE -co OVERVIEWS=IGNORE_EXISTINGNONE -co ADD_ALPHA=NO -co RESAMPLING=NEAREST -co BLOCKSIZE=512 <input_raster>.tif <output_raster>.tif
 
 Inspecting a raster file
 ------------------------

--- a/raster_loader/errors.py
+++ b/raster_loader/errors.py
@@ -23,7 +23,7 @@ class IncompatibleRasterException(Exception):
             "You can make your raster compatible "
             "by converting it using the following command:\n"
             "gdalwarp -of COG -co TILING_SCHEME=GoogleMapsCompatible "
-            "-co COMPRESS=DEFLATE -co OVERVIEWS=IGNORE_EXISTING -co ADD_ALPHA=YES "
+            "-co COMPRESS=DEFLATE -co OVERVIEWS=IGNORE_EXISTING -co ADD_ALPHA=NO"
             "-co RESAMPLING=NEAREST -co BLOCKSIZE=512 "
             "<input_raster>.tif <output_raster>.tif"
         )


### PR DESCRIPTION
* Use `-co OVERVIEWS=IGNORE_EXISTING` so that overviews are generated
* keep `-co ADD_ALPHA=NO` as the safest general choice (but it would be recommended to convert exiting nodata values to an alpha band with the GTiff driver and use `ADD_ALPHA=YES`