### PR TITLE
fix: support NumPy 2.0

### DIFF
--- a/raster_loader/io/common.py
+++ b/raster_loader/io/common.py
@@ -31,9 +31,9 @@ DEFAULT_TYPES_NODATA_VALUES = {
     "uint16": 65535,
     "uint32": 4294967295,
     "uint64": 18446744073709551615,
-    "float16": np.NaN,
-    "float32": np.NaN,
-    "float64": np.NaN,
+    "float16": np.nan,
+    "float32": np.nan,
+    "float64": np.nan,
 }
 
 should_swap = {"=": sys.byteorder != "little", "<": False, ">": True, "|": False}
@@ -49,7 +49,7 @@ def get_nodata_value(raster_dataset: rasterio.io.DatasetReader) -> float:
     if raster_dataset.nodata is None:
         for band in raster_dataset.indexes:
             band_value = band_nodata_value(raster_dataset, band)
-            # Note (np.NaN != np.NaN) == True
+            # Note (np.nan != np.nan) == True
             both_nan = np.isnan(band_value) and np.isnan(value)
             if (not both_nan) and (band_value != value):
                 raise ValueError("Invalid no data value")


### PR DESCRIPTION
## Issue

```
    Received: "Command failed: carto snowflake upload --file_url https://storage.googleapis.com/carto_test_tables/raster/medium_cog.tif --database CI --schema CI_TMP_UPLOADS --table TEST_23C23309B13257C3A0381475 --account sxa81489.us-east-1·
    Traceback (most recent call last):
      File \"/usr/local/bin/carto\", line 5, in <module>
        from raster_loader.cli import main
      File \"/usr/local/lib/python3.9/dist-packages/raster_loader/__init__.py\", line 3, in <module>
        from raster_loader.io.bigquery import (
      File \"/usr/local/lib/python3.9/dist-packages/raster_loader/io/bigquery.py\", line 10, in <module>
        from raster_loader.io.common import (
      File \"/usr/local/lib/python3.9/dist-packages/raster_loader/io/common.py\", line 34, in <module>
        \"float16\": np.NaN,
      File \"/usr/local/lib/python3.9/dist-packages/numpy/__init__.py\", line 397, in __getattr__
        raise AttributeError(
    AttributeError: `np.NaN` was removed in the NumPy 2.0 release. Use `np.nan` instead.
```

