### PR TITLE
Add metadata for Builder Rasters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,11 @@ carto_credentials.json
 
 # written by setuptools_scm
 */_version.py
+.idea/encodings.xml
+.idea/misc.xml
+.idea/modules.xml
+.idea/raster-loader.iml
+.idea/vcs.xml
+.idea/codeStyles/codeStyleConfig.xml
+.idea/codeStyles/Project.xml
+.idea/.gitignore

--- a/raster_loader/io/common.py
+++ b/raster_loader/io/common.py
@@ -4,6 +4,7 @@ import pyproj
 import shapely
 import numpy as np
 
+from raster_loader._version import __version__
 from collections import Counter
 from typing import Iterable
 from typing import Callable
@@ -356,7 +357,8 @@ def raster_band_stats(raster_dataset: rasterio.io.DatasetReader, band: int) -> d
     quantiles = dict(zip(range(3, 20), quantiles))
     most_common = Counter(qdata).most_common(100)
     most_common.sort(key=lambda x: x[1], reverse=True)
-    most_common = [int(x[0]) for x in most_common]
+    most_common = dict([(int(x[0]), x[1]) for x in most_common])
+    version = ".".join(__version__.split(".")[:3])
     return {
         "min": float(stats.min()),
         "max": float(stats.max()),
@@ -366,6 +368,7 @@ def raster_band_stats(raster_dataset: rasterio.io.DatasetReader, band: int) -> d
         "sum_squares": float((stats**2).sum()),
         "quantiles": quantiles,
         "top_values": most_common,
+        "version": version,
         "count": np.count_nonzero(stats.mask is False)
         if masked
         else math.prod(stats.shape),  # noqa: E712

--- a/raster_loader/io/common.py
+++ b/raster_loader/io/common.py
@@ -4,6 +4,7 @@ import pyproj
 import shapely
 import numpy as np
 
+from collections import Counter
 from typing import Iterable
 from typing import Callable
 from typing import List
@@ -347,6 +348,15 @@ def raster_band_stats(raster_dataset: rasterio.io.DatasetReader, band: int) -> d
             else:
                 (raw_data, mask) = band_with_nodata_mask(raster_dataset, band)
             stats = np.ma.masked_array(data=raw_data, mask=mask)
+    qdata = stats.compressed()
+    ranges = [[j / i for j in range(1, i)] for i in range(3, 20)]
+    quantiles = [
+        [int(np.quantile(qdata, q, method="lower")) for q in r] for r in ranges
+    ]
+    quantiles = dict(zip(range(3, 20), quantiles))
+    most_common = Counter(qdata).most_common(100)
+    most_common.sort(key=lambda x: x[1], reverse=True)
+    most_common = [int(x[0]) for x in most_common]
     return {
         "min": float(stats.min()),
         "max": float(stats.max()),
@@ -354,6 +364,8 @@ def raster_band_stats(raster_dataset: rasterio.io.DatasetReader, band: int) -> d
         "stddev": float(stats.std()),
         "sum": float(stats.sum()),
         "sum_squares": float((stats**2).sum()),
+        "quantiles": quantiles,
+        "top_values": most_common,
         "count": np.count_nonzero(stats.mask is False)
         if masked
         else math.prod(stats.shape),  # noqa: E712


### PR DESCRIPTION
chore: Update .gitignore
add: Add quantiles and top_values stats to the band level metadata in the common.py.

## Issue

Fixes #
[Link the issue this PR is based on. All PRs need to be associated to at least
one issue in the issue tracker.]

## Proposed Changes

[Summarize the changes this PR contains. Describe how these changes resolve or
help resolve the issue linked above.]

## Pull Request Checklist

- [x] I have tested the changes locally

## Additional Information

[Anything else you'd like to include.]

Metadata example:
{'min': 0.0, 'max': 255.0, 'mean': 46.78931471701873, 'stddev': 44.4161335121091, 'sum': 7513241.0, 'sum_squares': 668322593.0, 'quantiles': {3: [0, 66], 4: [0, 48, 75], 5: [0, 31, 60, 81], 6: [0, 0, 48, 66, 86], 7: [0, 0, 37, 57, 71, 90], 8: [0, 0, 25, 48, 62, 75, 93], 9: [0, 0, 0, 40, 55, 66, 78, 95], 10: [0, 0, 0, 31, 48, 60, 70, 81, 97], 11: [0, 0, 0, 21, 42, 54, 63, 73, 84, 99], 12: [0, 0, 0, 0, 34, 48, 58, 66, 75, 86, 101], 13: [0, 0, 0, 0, 28, 42, 53, 61, 69, 77, 88, 103], 14: [0, 0, 0, 0, 18, 37, 48, 57, 64, 71, 79, 90, 106], 15: [0, 0, 0, 0, 0, 31, 43, 53, 60, 66, 73, 81, 91, 108], 16: [0, 0, 0, 0, 0, 25, 38, 48, 56, 62, 68, 75, 83, 93, 110], 17: [0, 0, 0, 0, 0, 15, 33, 44, 52, 59, 64, 70, 77, 84, 94, 113], 18: [0, 0, 0, 0, 0, 0, 28, 40, 48, 55, 61, 66, 72, 78, 86, 95, 115], 19: [0, 0, 0, 0, 0, 0, 23, 35, 44, 52, 58, 63, 68, 74, 80, 87, 96, 118]}, 'top_values': {0: 56277, 63: 1867, 62: 1790, 64: 1749, 66: 1650, 65: 1616, 61: 1614, 56: 1592, 55: 1572, 60: 1570, 57: 1568, 67: 1557, 68: 1555, 58: 1527, 73: 1527, 54: 1516, 71: 1496, 69: 1493, 74: 1491, 72: 1471, 70: 1457, 75: 1442, 59: 1422, 79: 1353, 80: 1348, 76: 1344, 78: 1339, 53: 1336, 77: 1308, 42: 1266, 81: 1247, 84: 1233, 83: 1199, 43: 1193, 52: 1192, 51: 1179, 44: 1162, 82: 1154, 50: 1112, 91: 1068, 49: 1063, 48: 1062, 85: 1040, 45: 1031, 92: 1025, 87: 978, 47: 966, 41: 960, 95: 957, 28: 956, 46: 955, 88: 950, 90: 944, 96: 939, 93: 934, 89: 930, 86: 930, 97: 925, 40: 901, 94: 892, 38: 865, 29: 853, 39: 831, 33: 830, 34: 805, 30: 769, 37: 762, 31: 748, 32: 737, 98: 735, 36: 729, 35: 683, 27: 586, 101: 542, 100: 540, 99: 529, 19: 506, 26: 482, 102: 477, 25: 471, 24: 455, 23: 448, 103: 427, 104: 422, 22: 417, 20: 400, 21: 367, 106: 346, 107: 333, 18: 332, 105: 324, 108: 292, 109: 291, 111: 256, 110: 249, 112: 229, 17: 220, 113: 219, 114: 211, 118: 207}, 'version': '0.7.2', 'count': 0}
