### PR TITLE
chore: remove support for python3.8 and add 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,4 @@ repos:
       hooks:
           - id: flake8
             language: python_venv
+            additional_dependencies: [flake8-typing-imports==1.10.0]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,7 @@ repos:
           - id: black
             language_version: python3
     - repo: https://github.com/pycqa/flake8
-      rev: 5.0.4
+      rev: 7.1.1
       hooks:
           - id: flake8
             language: python_venv
-            additional_dependencies: [flake8-typing-imports==1.10.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,129 +5,155 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+<!-- insertion marker -->
+
 ## [0.8.2] - 2024-10-07
 
 ### Bug Fixes
-- Fix casting in quantiles (#151)
+
+-   Fix casting in quantiles (#151)
 
 ## [0.8.1] - 2024-09-24
 
 ### Bug Fixes
-- Fix stats for unmasked rasters
+
+-   Fix stats for unmasked rasters
 
 ## [0.8.0] - 2024-09-17
 
 ### Added
-- Add metadata for Builder Rasters (#147)
+
+-   Add metadata for Builder Rasters (#147)
 
 ## [0.7.1] - 2024-07-05
 
 ### Bug Fixes
-- fix: support for Python 3.9 / NumPy 2.0 (#145)
+
+-   fix: support for Python 3.9 / NumPy 2.0 (#145)
 
 ## [0.7.0] - 2024-07-02
 
 ### Added
-- Support raster overviews (#140)
+
+-   Support raster overviews (#140)
 
 ### Enhancements
-- increase chunk-size to 10000 (#142)
+
+-   increase chunk-size to 10000 (#142)
 
 ### Bug Fixes
-- fix: make the gdalwarp examples consistent (#143)
+
+-   fix: make the gdalwarp examples consistent (#143)
 
 ## [0.6.1] - 2024-04-02
 
 ### Enhancements
-- Add a argument to skip interactive question on upload failure (#138)
+
+-   Add a argument to skip interactive question on upload failure (#138)
 
 ### Bug Fixes
-- fix: shapely.wkt import (#136)
-- fix: update pip commands to make it compatible with zsh (#137)
+
+-   fix: shapely.wkt import (#136)
+-   fix: update pip commands to make it compatible with zsh (#137)
 
 ## [0.6.0] - 2024-03-25
 
 ### Enhancements
-- Add labels to BQ uploaded tables (#131)
-- Support input URLs and more connection credential types (#129)
+
+-   Add labels to BQ uploaded tables (#131)
+-   Support input URLs and more connection credential types (#129)
 
 ### Bug Fixes
-- fixed using raster files with block size other than default value (#130)
-- fix: error when bigquery dependencies not installed (#133)
+
+-   fixed using raster files with block size other than default value (#130)
+-   fix: error when bigquery dependencies not installed (#133)
 
 ## [0.5.0] - 2024-01-05
 
 ### Enhancements
-- Add support for snowflake (#127)
+
+-   Add support for snowflake (#127)
 
 ## [0.4.0] - 2023-12-21
 
 ### Enhancements
-- Update raster-loader to generate new Raster and Metadata table format (#116)
-- Add pixel_resolution, rename block_resolution (#123)
+
+-   Update raster-loader to generate new Raster and Metadata table format (#116)
+-   Add pixel_resolution, rename block_resolution (#123)
 
 ### Bug Fixes
-- fix: metadata field pixel_resolution as an integer and not allow zooms over 26 (#124, #125)
+
+-   fix: metadata field pixel_resolution as an integer and not allow zooms over 26 (#124, #125)
 
 ## [0.3.3] - 2023-10-30
 
 ### Bug Fixes
-- Fixed issue in parsing long json decimals (#117)
+
+-   Fixed issue in parsing long json decimals (#117)
 
 ## [0.3.2] - 2023-09-15
 
 ### Enhancements
-- Add append option to skip check (#114)
+
+-   Add append option to skip check (#114)
 
 ## [0.3.1] - 2023-04-21
 
 ### Enhancements
-- Store raster nodata value in table metadata (#111)
-- Add level to raster metadata (#110)
+
+-   Store raster nodata value in table metadata (#111)
+-   Add level to raster metadata (#110)
 
 ### Bug Fixes
-- Fixed issue in metadata when updating table (#112)
+
+-   Fixed issue in metadata when updating table (#112)
 
 ## [0.3.0] - 2023-03-07
 
 ### Enhancements
-- Create raster tables with geography and metadata (#105)
+
+-   Create raster tables with geography and metadata (#105)
 
 ### Bug Fixes
-- Fixed band in field name (#102)
-- Dockerfile - avoid installing GDAL twice (#104)
+
+-   Fixed band in field name (#102)
+-   Dockerfile - avoid installing GDAL twice (#104)
 
 ## [0.2.0] - 2023-01-26
 
 ### Enhancements
-- Updated setup.cfg and readme (#70)
-- Bumped wheel from 0.37.1 to 0.38.1 (#63)
-- Added a basic docker-compose based dev environment (#80)
-- Use quadbin (#72)
-- Raise rasterio.errors.CRSError for invalid CRS and Add test error condition (#89)
-- Cluster "quadbin raster" table by quadbin (#95)
-- Changed the endianess to little endian to accomodate the front end (#97)
+
+-   Updated setup.cfg and readme (#70)
+-   Bumped wheel from 0.37.1 to 0.38.1 (#63)
+-   Added a basic docker-compose based dev environment (#80)
+-   Use quadbin (#72)
+-   Raise rasterio.errors.CRSError for invalid CRS and Add test error condition (#89)
+-   Cluster "quadbin raster" table by quadbin (#95)
+-   Changed the endianess to little endian to accomodate the front end (#97)
 
 ### Bug Fixes
-- Fixed swapped lon lat (#75)
-- Fixed performance regression bug (#77)
-- Added small speed hack (#79)
+
+-   Fixed swapped lon lat (#75)
+-   Fixed performance regression bug (#77)
+-   Added small speed hack (#79)
 
 ### Documentation
-- Added docs badge and readthedocs link to readme (#69)
-- Updated contributor guide (#91)
-- Updated docs for quadbin (#93)
+
+-   Added docs badge and readthedocs link to readme (#69)
+-   Updated contributor guide (#91)
+-   Updated docs for quadbin (#93)
 
 ## [0.1.0] - 2023-01-05
 
 ### Added
-- raster_loader module
-  - rasterio_to_bigquery function
-  - bigquery_to_records function
-- rasterio_to_bigquery.cli submodule
-  - upload command
-  - describe command
-  - info command
-- docs
-- tests
-- CI/CD with GitHub Actions
+
+-   raster_loader module
+    -   rasterio_to_bigquery function
+    -   bigquery_to_records function
+-   rasterio_to_bigquery.cli submodule
+    -   upload command
+    -   describe command
+    -   info command
+-   docs
+-   tests
+-   CI/CD with GitHub Actions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,8 @@ If you don't have `make` available, you can open the file `Makefile` and run the
 commands manually to set up a virtual environment and install the dependencies.
 
 After creating your environment, you can enter the virtual environment with
-``source env/bin/activate`` on Linux and macOS or ``env\bin\Activate.ps1`` on Windows
+`source env/bin/activate` on Linux and macOS or `env\bin\Activate.ps1` on Windows
 (PowerShell).
-
 
 ### Setting up your environment (Docker / Docker-Compose)
 
@@ -58,7 +57,7 @@ development environment using Docker:
 
 1. Install Docker and Docker Compose on your system by following the instructions for your operating system from the official Docker website.
 2. Use `git clone` to clone [the Raster Loader repository](https://github.com/CartoDB/raster-loader)
-to your local machine.
+   to your local machine.
 3. Navigate to the root directory of the repository in your terminal.
 4. Run `make docker-build` command to build the docker image
 5. Run `make docker-start` to start the development environment. Keep this process running.
@@ -72,7 +71,7 @@ to your local machine.
 13. Run `make docker-stop` to stop the development environment
 14. Run `make docker-remove` to remove docker raster_loader Container/Network/Volume from your system
 
-*Note: If you want to make changes to library dependencies (i.e. requirements.txt or requirements-dev.txt) while the container is running, you'll need to rebuild the image using the make docker-build command and restart the container."*
+_Note: If you want to make changes to library dependencies (i.e. requirements.txt or requirements-dev.txt) while the container is running, you'll need to rebuild the image using the make docker-build command and restart the container."_
 
 ### Tests and linting
 
@@ -89,7 +88,7 @@ make lint
 
 This runs [flake8](https://flake8.pycqa.org/en/latest/) and
 [black](https://black.readthedocs.io/en/stable/). You can also run these tools
-individually using the ``flake8`` or ``black`` command.
+individually using the `flake8` or `black` command.
 
 #### Running tests
 
@@ -101,7 +100,7 @@ make test
 ```
 
 This runs all tests in the `tests` directory. You can also run all tests with the
-``pytest`` command.
+`pytest` command.
 
 The test suite includes optional integration tests that require credentials for a
 BigQuery account. To run these tests, you need to set the `GOOGLE_APPLICATION_CREDENTIALS`
@@ -191,3 +190,11 @@ to indicate that it is not ready for review.
 
 Before merging a pull request, the Raster Loader maintainers will review your code and
 might request changes. You can make changes to your pull request by pushing new commits.
+
+### Commit messages and changelog
+
+Raster loader uses Semantic Versioning and Conventional Commits. Format your PR and commit messages accordingly.
+
+To update the changelog before a new release, run the following in your terminal:
+
+$ git-changelog --output CHANGELOG.md --in-place --filter-commits "v0.8.2.."

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Python library for loading GIS raster data to standard cloud-based data warehouses that
 don't natively support raster data.
 
-Raster Loader is currently tested on Python 3.8, 3.9, 3.10, and 3.11.
+Raster Loader is currently tested on Python 3.9, 3.10, 3.11 and 3.12.
 
 ## Documentation
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 black==24.3.0
 flake8==4.0.1
+importlib-metadata==4.8.3
 ipython>=7.8.0
 lazydocs==0.4.8
 myst-parser==0.18.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 black==24.3.0
-flake8==4.0.1
-importlib-metadata==4.8.3
+flake8>=7.0.0
+importlib-metadata<5
 ipython>=7.8.0
 lazydocs==0.4.8
 myst-parser==0.18.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,3 +17,4 @@ sphinx==5.3.0
 tokenize-rt>=3.2.0
 twine==4.0.0
 wheel==0.38.1
+git-changelog==2.5.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ pytest-cov==3.0.0
 pytest-mock==3.8.2
 pytest==7.1.2
 requests-mock==1.9.3
+setuptools>=75.3.0
 sphinx-click==4.3.0
 sphinx-rtd-theme==1.1.1
 sphinx==5.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,14 +19,14 @@ classifiers =
     License :: OSI Approved :: BSD License
     Natural Language :: English
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 
 [options]
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.9
 setup_requires = setuptools_scm
 install_requires =
     click-plugins>=1.1.1


### PR DESCRIPTION
## Issue

Python 3.8 has reached its EOL. For this reason and for compatibility with `rasterio` library, we need to stop giving support to this python version.

## Proposed Changes

We have removed the CI pipeline that takes care of the python 3.8 version and added support for python 3.12.

In order to support python 3.12, `flake8` and its dependency `importlib-metadata` have been updated, and `setuptools` has been added as a dependency in `requirements-dev.txt` as it is used during testing.

In addition, we have updated the setup and the documentation so that they reflex these changes.

## Pull Request Checklist

- [ ] I have tested the changes locally
- [ ] I have added tests to cover my changes (if applicable)
- [X] I have updated the documentation (if applicable)


