### PR TITLE
Bug/sc 456192/top value parameter should be present by default

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,3 @@
 # === Raster Loader Environment Variables ===
+GOOGLE_APPLICATION_CREDENTIALS=/usr/local/gcloud/credentials.json
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 <small>[Compare with latest](https://github.com/CartoDB/raster-loader/compare/v0.9.1...HEAD)</small>
+### Added
+
+- Add: Compute top values only for integer bands ([6c10cc0](https://github.com/CartoDB/raster-loader/commit/6c10cc025f5691f7841beee560437fb591bddfe9) by Roberto Antolín).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- insertion marker -->
+## Unreleased
+
+<small>[Compare with latest](https://github.com/CartoDB/raster-loader/compare/v0.9.1...HEAD)</small>
+
+### Fixed
+
+- Fix: Tackle degenerate case of stdev computation ([b112c80](https://github.com/CartoDB/raster-loader/commit/b112c80be7d7c1adfd08f651b43dc591fd54a2ef) by Roberto Antolín).
+- Fix: Get count stats from shape of raster band ([c066a30](https://github.com/CartoDB/raster-loader/commit/c066a307ee116598c54ea4871d563f79deebad0b) by Roberto Antolín).
+- Fix: Raise error when 0 non-masked samples due to sparse rasters ([dfd89ae](https://github.com/CartoDB/raster-loader/commit/dfd89aef27726a3217843022769600315d8e5b6f) by Roberto Antolín).
+
+### Changed
+
+- Change '--all_stats' flag to '--omit_stats' ([805677f](https://github.com/CartoDB/raster-loader/commit/805677f26c73c0426a7d8600af358b213dd6797c) by Roberto Antolín).
 
 ## [0.9.1] 2024-11-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change '--all_stats' flag to '--omit_stats' ([805677f](https://github.com/CartoDB/raster-loader/commit/805677f26c73c0426a7d8600af358b213dd6797c) by Roberto Antolín).
+- Change '--all_stats' flag to '--basic_stats' ([2cb89cc](https://github.com/CartoDB/raster-loader/pull/156/commits/2cb89cca30eb15189c876760c026074e262cc10f) by Roberto Antolín).
 
 ## [0.9.1] 2024-11-26
 

--- a/raster_loader/cli/bigquery.py
+++ b/raster_loader/cli/bigquery.py
@@ -85,7 +85,7 @@ def bigquery(args=None):
 )
 @click.option(
     "--omit_stats",
-    help="Omit quantiles and most frequent values statistics .",
+    help="Omit quantiles and most frequent values statistics.",
     required=False,
     is_flag=True,
 )

--- a/raster_loader/cli/bigquery.py
+++ b/raster_loader/cli/bigquery.py
@@ -84,8 +84,8 @@ def bigquery(args=None):
     is_flag=True,
 )
 @click.option(
-    "--omit_stats",
-    help="Omit quantiles and most frequent values statistics.",
+    "--basic_stats",
+    help="Compute basic stats and omit quantiles and most frequent values.",
     required=False,
     is_flag=True,
 )
@@ -104,7 +104,7 @@ def upload(
     append=False,
     cleanup_on_failure=False,
     exact_stats=False,
-    omit_stats=False,
+    basic_stats=False,
 ):
     from raster_loader.io.common import (
         get_number_of_blocks,
@@ -176,7 +176,7 @@ def upload(
         append=append,
         cleanup_on_failure=cleanup_on_failure,
         exact_stats=exact_stats,
-        omit_stats=omit_stats,
+        basic_stats=basic_stats,
     )
 
     click.echo("Raster file uploaded to Google BigQuery")

--- a/raster_loader/cli/bigquery.py
+++ b/raster_loader/cli/bigquery.py
@@ -84,8 +84,8 @@ def bigquery(args=None):
     is_flag=True,
 )
 @click.option(
-    "--all_stats",
-    help="Compute all statistics including quantiles and most frequent values.",
+    "--omit_stats",
+    help="Omit quantiles and most frequent values statistics .",
     required=False,
     is_flag=True,
 )
@@ -104,7 +104,7 @@ def upload(
     append=False,
     cleanup_on_failure=False,
     exact_stats=False,
-    all_stats=False,
+    omit_stats=False,
 ):
     from raster_loader.io.common import (
         get_number_of_blocks,
@@ -176,7 +176,7 @@ def upload(
         append=append,
         cleanup_on_failure=cleanup_on_failure,
         exact_stats=exact_stats,
-        all_stats=all_stats,
+        omit_stats=omit_stats,
     )
 
     click.echo("Raster file uploaded to Google BigQuery")

--- a/raster_loader/cli/snowflake.py
+++ b/raster_loader/cli/snowflake.py
@@ -93,8 +93,8 @@ def snowflake(args=None):
     is_flag=True,
 )
 @click.option(
-    "--omit_stats",
-    help="Omit quantiles and most frequent values statistics.",
+    "--basic_stats",
+    help="Compute basic stats and omit quantiles and most frequent values.",
     required=False,
     is_flag=True,
 )
@@ -117,7 +117,7 @@ def upload(
     append=False,
     cleanup_on_failure=False,
     exact_stats=False,
-    omit_stats=False,
+    basic_stats=False,
 ):
     from raster_loader.io.common import (
         get_number_of_blocks,
@@ -200,7 +200,7 @@ def upload(
         append=append,
         cleanup_on_failure=cleanup_on_failure,
         exact_stats=exact_stats,
-        omit_stats=omit_stats,
+        basic_stats=basic_stats,
     )
 
     click.echo("Raster file uploaded to Snowflake")

--- a/raster_loader/cli/snowflake.py
+++ b/raster_loader/cli/snowflake.py
@@ -93,7 +93,7 @@ def snowflake(args=None):
     is_flag=True,
 )
 @click.option(
-    "--all_stats",
+    "--omit_stats",
     help="Compute all statistics including quantiles and most frequent values.",
     required=False,
     is_flag=True,
@@ -117,7 +117,7 @@ def upload(
     append=False,
     cleanup_on_failure=False,
     exact_stats=False,
-    all_stats=False,
+    omit_stats=False,
 ):
     from raster_loader.io.common import (
         get_number_of_blocks,
@@ -200,7 +200,7 @@ def upload(
         append=append,
         cleanup_on_failure=cleanup_on_failure,
         exact_stats=exact_stats,
-        all_stats=all_stats,
+        omit_stats=omit_stats,
     )
 
     click.echo("Raster file uploaded to Snowflake")

--- a/raster_loader/cli/snowflake.py
+++ b/raster_loader/cli/snowflake.py
@@ -94,7 +94,7 @@ def snowflake(args=None):
 )
 @click.option(
     "--omit_stats",
-    help="Compute all statistics including quantiles and most frequent values.",
+    help="Omit quantiles and most frequent values statistics.",
     required=False,
     is_flag=True,
 )

--- a/raster_loader/io/bigquery.py
+++ b/raster_loader/io/bigquery.py
@@ -108,7 +108,7 @@ class BigQueryConnection(DataWarehouseConnection):
         append: bool = False,
         cleanup_on_failure: bool = False,
         exact_stats: bool = False,
-        omit_stats: bool = False,
+        basic_stats: bool = False,
     ):
         """Write a raster file to a BigQuery table."""
         print("Loading raster file to BigQuery...")
@@ -131,7 +131,7 @@ class BigQueryConnection(DataWarehouseConnection):
                         exit()
 
             metadata = rasterio_metadata(
-                file_path, bands_info, self.band_rename_function, exact_stats, omit_stats
+                file_path, bands_info, self.band_rename_function, exact_stats, basic_stats
             )
 
             overviews_records_gen = rasterio_overview_to_records(

--- a/raster_loader/io/bigquery.py
+++ b/raster_loader/io/bigquery.py
@@ -108,7 +108,7 @@ class BigQueryConnection(DataWarehouseConnection):
         append: bool = False,
         cleanup_on_failure: bool = False,
         exact_stats: bool = False,
-        all_stats: bool = False,
+        omit_stats: bool = False,
     ):
         """Write a raster file to a BigQuery table."""
         print("Loading raster file to BigQuery...")
@@ -131,7 +131,7 @@ class BigQueryConnection(DataWarehouseConnection):
                         exit()
 
             metadata = rasterio_metadata(
-                file_path, bands_info, self.band_rename_function, exact_stats, all_stats
+                file_path, bands_info, self.band_rename_function, exact_stats, omit_stats
             )
 
             overviews_records_gen = rasterio_overview_to_records(

--- a/raster_loader/io/common.py
+++ b/raster_loader/io/common.py
@@ -576,14 +576,14 @@ def raster_band_stats(
     _mean = _stats.mean
     _std = _stats.std
 
-    count = math.prod(_stats.shape)
+    raster_band = read_raster_band(raster_dataset=raster_dataset, band=band)
+
+    count = math.prod(raster_band.shape)
     if is_masked_band(raster_dataset, band):
-        count = np.count_nonzero(_stats.mask is False)
+        count = np.count_nonzero(raster_band.mask is False)
 
     _sum = _mean * count
     sum_squares = count * _std**2 + _mean**2
-
-    raster_band = read_raster_band(raster_dataset=raster_dataset, band=band)
 
     print("Removing masked data...")
     qdata = raster_band.compressed()

--- a/raster_loader/io/common.py
+++ b/raster_loader/io/common.py
@@ -429,6 +429,13 @@ def sample_not_masked_values(
         iterations += 1
 
     if len(not_masked_samples[1]) < n_samples:
+        if len(not_masked_samples[1]) == 0:
+            raise ValueError(
+                "The data is very sparse and no non-masked samples were collected.\n"
+                "Please, consider to use the --exact_stats option to compute exact "
+                "stats"
+            )
+
         warnings.warn(
             "The data is very sparse and there are not enough non-masked samples.\n"
             f"Only {len(not_masked_samples[1])} samples were collected and "

--- a/raster_loader/io/common.py
+++ b/raster_loader/io/common.py
@@ -598,16 +598,11 @@ def raster_band_stats(
 
         quantiles = compute_quantiles(qdata, casting_function)
 
-        print("Computing most commons values...")
-        if casting_function == float:
-            warnings.warn(
-                "Most common values are meant for categorical data. "
-                "Computing them for float bands can be meaningless.\n"
-                "Please, consider to use the --basic_stats option.",
-            )
-        most_common = Counter(qdata).most_common(100)
-        most_common.sort(key=lambda x: x[1], reverse=True)
-        most_common = dict([(casting_function(x[0]), x[1]) for x in most_common])
+        if casting_function == int:
+            print("Computing most commons values...")
+            most_common = Counter(qdata).most_common(100)
+            most_common.sort(key=lambda x: x[1], reverse=True)
+            most_common = dict([(casting_function(x[0]), x[1]) for x in most_common])
 
     version = ".".join(__version__.split(".")[:3])
 

--- a/raster_loader/io/common.py
+++ b/raster_loader/io/common.py
@@ -1004,7 +1004,10 @@ def update_metadata(metadata, old_metadata):
             stdev = math.sqrt(old_stats["stddev"] ** 2 + new_stats["stddev"] ** 2)
         else:
             mean = _sum / count
-            stdev = math.sqrt(sum_squares / count - mean * mean)
+            try:
+                stdev = math.sqrt(sum_squares / count - mean * mean)
+            except ValueError:
+                stdev = math.sqrt(old_stats["stddev"] ** 2 + new_stats["stddev"] ** 2)
 
         approximated_stats = (
             old_stats["approximated_stats"] or new_stats["approximated_stats"]

--- a/raster_loader/io/common.py
+++ b/raster_loader/io/common.py
@@ -191,7 +191,7 @@ def rasterio_metadata(
     bands_info: List[Tuple[int, str]],
     band_rename_function: Callable,
     exact_stats: bool = False,
-    omit_stats: bool = False,
+    basic_stats: bool = False,
 ):
     """Open a raster file with rasterio."""
     raster_info = rio_cogeo.cog_info(file_path).dict()
@@ -243,11 +243,11 @@ def rasterio_metadata(
                     "User is encourage to compute approximate statistics instead.",
                     UserWarning,
                 )
-                stats = raster_band_stats(raster_dataset, band, omit_stats)
+                stats = raster_band_stats(raster_dataset, band, basic_stats)
             else:
                 print("Computing approximate stats...")
                 stats = raster_band_approx_stats(
-                    raster_dataset, samples, band, omit_stats
+                    raster_dataset, samples, band, basic_stats
                 )
 
             band_colorinterp = get_color_name(raster_dataset, band)
@@ -483,7 +483,7 @@ def raster_band_approx_stats(
     raster_dataset: rasterio.io.DatasetReader,
     samples: Samples,
     band: int,
-    omit_stats: bool,
+    basic_stats: bool,
 ) -> dict:
     """Get approximate statistics for a raster band."""
 
@@ -498,7 +498,7 @@ def raster_band_approx_stats(
         _sum = int(np.sum(samples_band))
         sum_squares = int(np.sum(np.array(samples_band) ** 2))
 
-    if omit_stats:
+    if basic_stats:
         quantiles = None
         most_common = None
     else:
@@ -564,7 +564,7 @@ def read_raster_band(raster_dataset: rasterio.io.DatasetReader, band: int) -> np
 
 
 def raster_band_stats(
-    raster_dataset: rasterio.io.DatasetReader, band: int, omit_stats: bool
+    raster_dataset: rasterio.io.DatasetReader, band: int, basic_stats: bool
 ) -> dict:
     """Get statistics for a raster band."""
 
@@ -588,7 +588,7 @@ def raster_band_stats(
     print("Removing masked data...")
     qdata = raster_band.compressed()
 
-    if omit_stats:
+    if basic_stats:
         quantiles = None
         most_common = None
     else:
@@ -603,7 +603,7 @@ def raster_band_stats(
             warnings.warn(
                 "Most common values are meant for categorical data. "
                 "Computing them for float bands can be meaningless.\n"
-                "Please, consider to use the --omit_stats option.",
+                "Please, consider to use the --basic_stats option.",
             )
         most_common = Counter(qdata).most_common(100)
         most_common.sort(key=lambda x: x[1], reverse=True)

--- a/raster_loader/io/snowflake.py
+++ b/raster_loader/io/snowflake.py
@@ -179,7 +179,7 @@ class SnowflakeConnection(DataWarehouseConnection):
         append: bool = False,
         cleanup_on_failure: bool = False,
         exact_stats: bool = False,
-        all_stats: bool = False,
+        omit_stats: bool = False,
     ) -> bool:
         def band_rename_function(x):
             return x.upper()
@@ -207,7 +207,7 @@ class SnowflakeConnection(DataWarehouseConnection):
                     exit()
 
             metadata = rasterio_metadata(
-                file_path, bands_info, band_rename_function, exact_stats, all_stats
+                file_path, bands_info, band_rename_function, exact_stats, omit_stats
             )
 
             overviews_records_gen = rasterio_overview_to_records(

--- a/raster_loader/io/snowflake.py
+++ b/raster_loader/io/snowflake.py
@@ -179,7 +179,7 @@ class SnowflakeConnection(DataWarehouseConnection):
         append: bool = False,
         cleanup_on_failure: bool = False,
         exact_stats: bool = False,
-        omit_stats: bool = False,
+        basic_stats: bool = False,
     ) -> bool:
         def band_rename_function(x):
             return x.upper()
@@ -207,7 +207,7 @@ class SnowflakeConnection(DataWarehouseConnection):
                     exit()
 
             metadata = rasterio_metadata(
-                file_path, bands_info, band_rename_function, exact_stats, omit_stats
+                file_path, bands_info, band_rename_function, exact_stats, basic_stats
             )
 
             overviews_records_gen = rasterio_overview_to_records(

--- a/raster_loader/tests/bigquery/test_cli.py
+++ b/raster_loader/tests/bigquery/test_cli.py
@@ -40,6 +40,33 @@ def test_bigquery_upload(*args, **kwargs):
 
 @patch("raster_loader.cli.bigquery.BigQueryConnection.upload_raster", return_value=None)
 @patch("raster_loader.cli.bigquery.BigQueryConnection.__init__", return_value=None)
+def test_bigquery_upload_with_omit_stats(*args, **kwargs):
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "bigquery",
+            "upload",
+            "--file_path",
+            f"{tiff}",
+            "--project",
+            "project",
+            "--dataset",
+            "dataset",
+            "--table",
+            "table",
+            "--chunk_size",
+            1,
+            "--band",
+            1,
+            "--omit_stats",
+        ],
+    )
+    assert result.exit_code == 0
+
+
+@patch("raster_loader.cli.bigquery.BigQueryConnection.upload_raster", return_value=None)
+@patch("raster_loader.cli.bigquery.BigQueryConnection.__init__", return_value=None)
 def test_bigquery_upload_with_all_stats(*args, **kwargs):
     runner = CliRunner()
     result = runner.invoke(

--- a/raster_loader/tests/bigquery/test_cli.py
+++ b/raster_loader/tests/bigquery/test_cli.py
@@ -40,7 +40,7 @@ def test_bigquery_upload(*args, **kwargs):
 
 @patch("raster_loader.cli.bigquery.BigQueryConnection.upload_raster", return_value=None)
 @patch("raster_loader.cli.bigquery.BigQueryConnection.__init__", return_value=None)
-def test_bigquery_upload_with_omit_stats(*args, **kwargs):
+def test_bigquery_upload_with_basic_stats(*args, **kwargs):
     runner = CliRunner()
     result = runner.invoke(
         main,
@@ -59,7 +59,7 @@ def test_bigquery_upload_with_omit_stats(*args, **kwargs):
             1,
             "--band",
             1,
-            "--omit_stats",
+            "--basic_stats",
         ],
     )
     assert result.exit_code == 0

--- a/raster_loader/tests/bigquery/test_cli.py
+++ b/raster_loader/tests/bigquery/test_cli.py
@@ -59,7 +59,6 @@ def test_bigquery_upload_with_all_stats(*args, **kwargs):
             1,
             "--band",
             1,
-            "--all_stats",
         ],
     )
     assert result.exit_code == 0

--- a/raster_loader/tests/snowflake/test_cli.py
+++ b/raster_loader/tests/snowflake/test_cli.py
@@ -50,7 +50,7 @@ def test_snowflake_upload(*args, **kwargs):
     "raster_loader.io.snowflake.SnowflakeConnection.upload_raster", return_value=None
 )
 @patch("raster_loader.io.snowflake.SnowflakeConnection.__init__", return_value=None)
-def test_snowflake_upload_with_omit_stats(*args, **kwargs):
+def test_snowflake_upload_with_basic_stats(*args, **kwargs):
     runner = CliRunner()
     result = runner.invoke(
         main,
@@ -75,7 +75,7 @@ def test_snowflake_upload_with_omit_stats(*args, **kwargs):
             1,
             "--band",
             1,
-            "--omit_stats",
+            "--basic_stats",
         ],
     )
     assert result.exit_code == 0

--- a/raster_loader/tests/snowflake/test_cli.py
+++ b/raster_loader/tests/snowflake/test_cli.py
@@ -50,6 +50,41 @@ def test_snowflake_upload(*args, **kwargs):
     "raster_loader.io.snowflake.SnowflakeConnection.upload_raster", return_value=None
 )
 @patch("raster_loader.io.snowflake.SnowflakeConnection.__init__", return_value=None)
+def test_snowflake_upload_with_omit_stats(*args, **kwargs):
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "snowflake",
+            "upload",
+            "--file_path",
+            f"{tiff}",
+            "--database",
+            "database",
+            "--schema",
+            "schema",
+            "--table",
+            "table",
+            "--account",
+            "account",
+            "--username",
+            "username",
+            "--password",
+            "password",
+            "--chunk_size",
+            1,
+            "--band",
+            1,
+            "--omit_stats",
+        ],
+    )
+    assert result.exit_code == 0
+
+
+@patch(
+    "raster_loader.io.snowflake.SnowflakeConnection.upload_raster", return_value=None
+)
+@patch("raster_loader.io.snowflake.SnowflakeConnection.__init__", return_value=None)
 def test_snowflake_upload_with_all_stats(*args, **kwargs):
     runner = CliRunner()
     result = runner.invoke(

--- a/raster_loader/tests/snowflake/test_cli.py
+++ b/raster_loader/tests/snowflake/test_cli.py
@@ -75,7 +75,6 @@ def test_snowflake_upload_with_all_stats(*args, **kwargs):
             1,
             "--band",
             1,
-            "--all_stats",
         ],
     )
     assert result.exit_code == 0


### PR DESCRIPTION
## Issue

https://app.shortcut.com/cartoteam/story/456192/top-value-parameter-should-be-present-by-default-in-raster-loader

## Proposed Changes

We have reversed the `--all_stats` flag into the `--omit_stats` in both `bigquery` and `snowflake` CLIs.

The new logic is that of calculate both top_values and quantiles by default and only omit them if specify by user `--omit_stats`.

In addition, we have fixed some other issues when:
1. Dealing with very sparse raster
2. Computing mean and stdev for exact stats
3. Colorinterp name

## Pull Request Checklist

- [X] I have tested the changes locally
- [X] I have added tests to cover my changes (if applicable)
- [ ] I have updated the documentation (if applicable)

