### PR TITLE
Fix typo in suggested command in error message

### DIFF
--- a/raster_loader/errors.py
+++ b/raster_loader/errors.py
@@ -23,7 +23,7 @@ class IncompatibleRasterException(Exception):
             "You can make your raster compatible "
             "by converting it using the following command:\n"
             "gdalwarp -of COG -co TILING_SCHEME=GoogleMapsCompatible "
-            "-co COMPRESS=DEFLATE -co OVERVIEWS=IGNORE_EXISTING -co ADD_ALPHA=NO"
+            "-co COMPRESS=DEFLATE -co OVERVIEWS=IGNORE_EXISTING -co ADD_ALPHA=NO "
             "-co RESAMPLING=NEAREST -co BLOCKSIZE=512 "
             "<input_raster>.tif <output_raster>.tif"
         )


### PR DESCRIPTION
## Issue

## Proposed Changes

Just adding a missing blank space between the suggested gdalwarp command options.

## Pull Request Checklist

- [ ] I have tested the changes locally
- [ ] I have added tests to cover my changes (if applicable)
- [ ] I have updated the documentation (if applicable)

## Additional Information

There is a missing space between options:
![image](https://github.com/user-attachments/assets/24a30528-943a-4811-8f88-f75e13b39e8c)

So if you simply copy-paste the suggested command and replace the files, you'll get an error.

