### PR TITLE
Feature/sc 455513/allow using key pair credentials in raster

### DIFF
--- a/raster_loader/cli/snowflake.py
+++ b/raster_loader/cli/snowflake.py
@@ -141,14 +141,24 @@ def upload(
         get_block_dims,
     )
 
-    if (
-        token is None
-        and (username is None or password is None)
-        and private_key_path is None
-    ) or all(v is not None for v in [token, username, password, private_key_path]):
+    if not (
+        (token is not None and username is None)
+        or (
+            token is None
+            and username is not None
+            and password is not None
+            and private_key_path is None
+        )
+        or (
+            token is None
+            and username is not None
+            and password is None
+            and private_key_path is not None
+        )
+    ):
         raise ValueError(
-            "Either --token or --private-key-path or --username and --password"
-            " must be provided."
+            "Either (--token) or (--username and --private-key-path) or"
+            " (--username and --password) must be provided."
         )
 
     if private_key_path is not None:
@@ -277,14 +287,24 @@ def describe(
     limit,
 ):
 
-    if (
-        token is None
-        and (username is None or password is None)
-        and private_key_path is None
-    ) or all(v is not None for v in [token, username, password, private_key_path]):
+    if not (
+        (token is not None and username is None)
+        or (
+            token is None
+            and username is not None
+            and password is not None
+            and private_key_path is None
+        )
+        or (
+            token is None
+            and username is not None
+            and password is None
+            and private_key_path is not None
+        )
+    ):
         raise ValueError(
-            "Either --token or --private-key-path or --username and --password"
-            " must be provided."
+            "Either (--token) or (--username and --private-key-path) or"
+            " (--username and --password) must be provided."
         )
 
     if private_key_path is not None:

--- a/raster_loader/cli/snowflake.py
+++ b/raster_loader/cli/snowflake.py
@@ -53,6 +53,7 @@ def snowflake(args=None):
     default=None,
 )
 @click.option("--role", help="The role to use for the file upload.", default=None)
+@click.option("--warehouse", help="Name of the default warehouse to use.", default=None)
 @click.option(
     "--file_path", help="The path to the raster file.", required=False, default=None
 )
@@ -119,6 +120,7 @@ def upload(
     private_key_path,
     private_key_passphrase,
     role,
+    warehouse,
     file_path,
     file_url,
     database,
@@ -189,6 +191,7 @@ def upload(
         database=database,
         schema=schema,
         role=role,
+        warehouse=warehouse,
     )
 
     source = file_path if is_local_file else file_url
@@ -254,6 +257,7 @@ def upload(
     default=None,
 )
 @click.option("--role", help="The role to use for the file upload.", default=None)
+@click.option("--warehouse", help="Name of the default warehouse to use.", default=None)
 @click.option("--database", help="The name of the database.", required=True)
 @click.option("--schema", help="The name of the schema.", required=True)
 @click.option("--table", help="The name of the table.", required=True)
@@ -266,6 +270,7 @@ def describe(
     private_key_path,
     private_key_passphrase,
     role,
+    warehouse,
     database,
     schema,
     table,
@@ -298,6 +303,7 @@ def describe(
         database=database,
         schema=schema,
         role=role,
+        warehouse=warehouse,
     )
     df = connector.get_records(fqn, limit)
     print(f"Table: {fqn}")

--- a/raster_loader/io/snowflake.py
+++ b/raster_loader/io/snowflake.py
@@ -44,6 +44,7 @@ class SnowflakeConnection(DataWarehouseConnection):
         private_key_path,
         private_key_passphrase,
         role,
+        warehouse,
     ):
         if not _has_snowflake:
             import_error_snowflake()
@@ -57,6 +58,7 @@ class SnowflakeConnection(DataWarehouseConnection):
                 database=database.upper(),
                 schema=schema.upper(),
                 role=role.upper() if role is not None else None,
+                warehouse=warehouse,
             )
         elif private_key_path is not None:
             self.client = snowflake.connector.connect(
@@ -68,6 +70,7 @@ class SnowflakeConnection(DataWarehouseConnection):
                 database=database.upper(),
                 schema=schema.upper(),
                 role=role.upper() if role is not None else None,
+                warehouse=warehouse,
             )
         else:
             self.client = snowflake.connector.connect(
@@ -77,6 +80,7 @@ class SnowflakeConnection(DataWarehouseConnection):
                 database=database.upper(),
                 schema=schema.upper(),
                 role=role.upper() if role is not None else None,
+                warehouse=warehouse,
             )
 
     def band_rename_function(self, band_name: str):

--- a/raster_loader/io/snowflake.py
+++ b/raster_loader/io/snowflake.py
@@ -33,15 +33,37 @@ else:
 
 
 class SnowflakeConnection(DataWarehouseConnection):
-    def __init__(self, username, password, account, database, schema, token, role):
+    def __init__(
+        self,
+        username,
+        password,
+        account,
+        database,
+        schema,
+        token,
+        private_key_path,
+        private_key_passphrase,
+        role,
+    ):
         if not _has_snowflake:
             import_error_snowflake()
 
         # TODO: Write a proper static factory for this
-        if token is None:
+        if token is not None:
             self.client = snowflake.connector.connect(
+                authenticator="oauth",
+                token=token,
+                account=account,
+                database=database.upper(),
+                schema=schema.upper(),
+                role=role.upper() if role is not None else None,
+            )
+        elif private_key_path is not None:
+            self.client = snowflake.connector.connect(
+                authenticator="snowflake_jwt",
                 user=username,
-                password=password,
+                private_key_file=private_key_path,
+                private_key_file_pwd=private_key_passphrase,
                 account=account,
                 database=database.upper(),
                 schema=schema.upper(),
@@ -49,8 +71,8 @@ class SnowflakeConnection(DataWarehouseConnection):
             )
         else:
             self.client = snowflake.connector.connect(
-                authenticator="oauth",
-                token=token,
+                user=username,
+                password=password,
                 account=account,
                 database=database.upper(),
                 schema=schema.upper(),

--- a/raster_loader/tests/snowflake/test_cli.py
+++ b/raster_loader/tests/snowflake/test_cli.py
@@ -181,7 +181,8 @@ def test_snowflake_credentials_validation(*args, **kwargs):
     )
     assert result.exit_code == 1
     assert (
-        "Either --token or --username and --password must be provided." in result.output
+        "Either (--token) or (--username and --private-key-path) or"
+        " (--username and --password) must be provided." in result.output
     )
 
     result = runner.invoke(
@@ -213,7 +214,8 @@ def test_snowflake_credentials_validation(*args, **kwargs):
     )
     assert result.exit_code == 1
     assert (
-        "Either --token or --username and --password must be provided." in result.output
+        "Either (--token) or (--username and --private-key-path) or"
+        " (--username and --password) must be provided." in result.output
     )
 
 

--- a/raster_loader/utils.py
+++ b/raster_loader/utils.py
@@ -37,6 +37,22 @@ def get_default_table_name(base_path: str, band):
     return re.sub(r"[^a-zA-Z0-9_-]", "_", table)
 
 
+def check_private_key(private_key_path: str, private_key_passphrase: str):
+    # Check that the private key file exists
+    if not os.path.exists(private_key_path):
+        raise ValueError(f"Private key file {private_key_path} not found")
+
+    with open(private_key_path, "r") as f:
+        private_key = f.read()
+        if (
+            private_key.startswith("-----BEGIN ENCRYPTED PRIVATE KEY-----")
+            and private_key_passphrase is None
+        ):
+            raise ValueError(
+                "The private key file is encrypted. Please provide a passphrase."
+            )
+
+
 # Modify the __init__ so that self.line = "" instead of None
 def new_init(
     self, message, category, filename, lineno, file=None, line=None, source=None


### PR DESCRIPTION
## Proposed Changes

Snowflake key pair authentication support. See: [Key-pair authentication](https://docs.snowflake.com/en/user-guide/key-pair-auth)

2 new options added to snowflake commands: 
`--private-key-path`: Path to your privake key in PEM format
`--private-key-passphrase`: Passphrase for private key if it's encrypted (optional)

Example:
```
carto snowflake upload \
  --file_url https://... \
  --database my-snowflake-database \
  --schema my-snowflake-schema \
  --table my-snowflake-table \
  --account my-snowflake-account \
  --warehouse my-warehouse \
  --username my-snowflake-user \
  --private-key-path /path/to/my/privatekey.pem \
  --private-key-passphrase my-passphrase \
  --band 1 \
  --cleanup-on-failure \
  --overwrite
```

## Pull Request Checklist

- [x] I have tested the changes locally

