### PR TITLE
fix: most_common_approx duplicated counts definition

### DIFF
--- a/raster_loader/io/common.py
+++ b/raster_loader/io/common.py
@@ -492,7 +492,6 @@ def most_common_approx(samples: List[Union[int, float]]) -> Dict[int, int]:
     counts, bin_edges = np.histogram(samples_array, bins=bins)
 
     nth = min(DEFAULT_MAX_MOST_COMMON, len(counts))
-    counts = np.bincount(samples)
     idx = np.argpartition(counts, -nth)[-nth:]
 
     return {int(bin_edges[i]): int(counts[i]) for i in idx if counts[i] > 0}


### PR DESCRIPTION
## Issue

Fixes #
- Fixed most_common_approx function: duplicated counts variable definition. Causing this error:

```carto bigquery upload   --file_path ~/Downloads/raster/blended_output_cog.tif   --project cartobq   --dataset cayetanobv_raster_tests   --table blended_output_compress --overwrite --compress --band 1 --band 2 --band 3
Preparing to upload raster file to BigQuery...
File Path: /home/cayetano/Downloads/raster/blended_output_cog.tif
File Size: 3279.5174951553345 MB
Number of bands: 3
Band types: ('uint8', 'uint8', 'uint8')
Band sizes (MB): [4096.0, 4096.0, 4096.0]
Source Band: (1, 2, 3)
Band Name: [None, None, None]
Number of Blocks: 65536
Block Dims: (256, 256)
Project: cartobq
Dataset: cayetanobv_raster_tests
Table: blended_output_compress
Number of Records Per BigQuery Append: 10000
Compress: True
Uploading Raster to BigQuery
Loading raster file to BigQuery...
Sampling raster...
Computing approximate stats...
Computing quantiles...
Computing most common values...
Computing approximate stats...
Computing quantiles...
Computing most common values...
Computing approximate stats...
Computing quantiles...
Computing most common values...
Error uploading to BigQuery. Would you like to delete the partially uploaded table? [yes/no] yes
Traceback (most recent call last):
  File "/home/cayetano/dev_projs/cartolibs/raster-loader/raster_loader/io/bigquery.py", line 135, in upload_raster
    metadata = rasterio_metadata(
               ^^^^^^^^^^^^^^^^^^
  File "/home/cayetano/dev_projs/cartolibs/raster-loader/raster_loader/io/common.py", line 273, in rasterio_metadata
    stats = raster_band_approx_stats(
            ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cayetano/dev_projs/cartolibs/raster-loader/raster_loader/io/common.py", line 556, in raster_band_approx_stats
    most_common = most_common_approx(samples_band)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cayetano/dev_projs/cartolibs/raster-loader/raster_loader/io/common.py", line 498, in most_common_approx
    return {int(bin_edges[i]): int(counts[i]) for i in idx if counts[i] > 0}
                ~~~~~~~~~^^^
IndexError: index 221 is out of bounds for axis 0 with size 61
None
Error: Error uploading to BigQuery: index 221 is out of bounds for axis 0 with size 61
```

## Pull Request Checklist

- [x] I have tested the changes locally
- [ ] I have added tests to cover my changes (if applicable)
- [ ] I have updated the documentation (if applicable)


