### PR TITLE
fix: matching compressions should be checked when appending rasters

### DIFF
--- a/raster_loader/io/common.py
+++ b/raster_loader/io/common.py
@@ -989,6 +989,12 @@ def check_metadata_is_compatible(metadata, old_metadata):
             f"({metadata['bands']} != {old_metadata['bands']})."
         )
 
+    if metadata.get("compression") != old_metadata.get("compression"):
+        raise ValueError(
+            "Cannot append records to a table with different compression."
+            f"({metadata.get('compression')} != {old_metadata.get('compression')})."
+        )
+
 
 def update_metadata(metadata, old_metadata):
     """Update a metadata object, combining it with another existing metadata object

--- a/raster_loader/io/snowflake.py
+++ b/raster_loader/io/snowflake.py
@@ -302,11 +302,7 @@ class SnowflakeConnection(DataWarehouseConnection):
 
             print("Writing metadata to Snowflake...")
             if append_records:
-                print("Appending records to Snowflake...")
-                print(f"Metadata: {metadata}")
-                print(f"Append records: {append_records}")
                 old_metadata = self.get_metadata(fqn)
-                print(f"Old metadata: {old_metadata}")
                 check_metadata_is_compatible(metadata, old_metadata)
                 update_metadata(metadata, old_metadata)
 

--- a/raster_loader/io/snowflake.py
+++ b/raster_loader/io/snowflake.py
@@ -237,7 +237,12 @@ class SnowflakeConnection(DataWarehouseConnection):
                     exit()
 
             metadata = rasterio_metadata(
-                file_path, bands_info, band_rename_function, exact_stats, basic_stats
+                file_path,
+                bands_info,
+                band_rename_function,
+                exact_stats,
+                basic_stats,
+                compress,
             )
 
             overviews_records_gen = rasterio_overview_to_records(
@@ -297,7 +302,11 @@ class SnowflakeConnection(DataWarehouseConnection):
 
             print("Writing metadata to Snowflake...")
             if append_records:
+                print("Appending records to Snowflake...")
+                print(f"Metadata: {metadata}")
+                print(f"Append records: {append_records}")
                 old_metadata = self.get_metadata(fqn)
+                print(f"Old metadata: {old_metadata}")
                 check_metadata_is_compatible(metadata, old_metadata)
                 update_metadata(metadata, old_metadata)
 


### PR DESCRIPTION
## Issue

Fixes #
- raster loader must consider compression when [sc-470644]

## Proposed Changes

We were not checking the compression when appending rasters and could end up on situations with part of the raster compressed and part not. I didn't add anything into `update_metadata` as we can keep the original compression value. This PR also fixes a little error in Snowflake where we were not passing the compress to the metadata.

## Pull Request Checklist

- [x] I have tested the changes locally
- [ ] I have added tests to cover my changes (if applicable)
- [ ] I have updated the documentation (if applicable)

## Additional Information

[Anything else you'd like to include.]
