### PR TITLE
Upgrade ubuntu-20.04 to ubuntu-24.04 runner version

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -5,7 +5,7 @@ on:
        - '*'
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@master
       - name: Set up Python 3.9


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/470573
- Autolink: [sc-470573]

In order to avoid deprecation and our CI/CD not running because we are using runners deprecated upgrade to the latest version available.