### PR TITLE
Fix band nodata value

### DIFF
--- a/raster_loader/io/common.py
+++ b/raster_loader/io/common.py
@@ -76,11 +76,8 @@ def band_original_nodata_value(
 def band_value_as_string(
     raster_dataset: rasterio.io.DatasetReader, band: int, value: float
 ) -> str:
-    return (
-        str(np.array(value).astype(raster_dataset.dtypes[band - 1]))
-        if value is not None
-        else None
-    )
+    tmpValue = np.array(value).astype(raster_dataset.dtypes[band - 1])
+    return str(value) if not np.isnan(tmpValue) else np.nan
 
 
 def band_nodata_value(raster_dataset: rasterio.io.DatasetReader, band: int) -> float:


### PR DESCRIPTION
## Issue

## Proposed Changes

The `np.astype` method was rounding the values in some cases, so we had discrepancies between `nodata` values in bands and general metadata values. For example `nodata: -9.999999933815813e+36` becomes `nodata: "-1e+37"` in bands.

The change simply uses numpy to manage `nan` values, but returning the string representation of the original value in valid cases.

## Pull Request Checklist

- [x] I have tested the changes locally
- [ ] I have added tests to cover my changes (if applicable)
- [ ] I have updated the documentation (if applicable)

## Additional Information

#### Before changes:
![image](https://github.com/user-attachments/assets/96369fa4-3284-4901-b725-d11b9a9c7128)

#### After changes:
![image](https://github.com/user-attachments/assets/0ad9b72e-687d-478c-9e3a-48a3fe0a003e)

