### PR TITLE
bugfix variable not initialized

### DIFF
--- a/raster_loader/io/common.py
+++ b/raster_loader/io/common.py
@@ -637,10 +637,9 @@ def raster_band_stats(
     print("Removing masked data...")
     qdata = raster_band.compressed()
 
-    if basic_stats:
-        quantiles = None
-        most_common = None
-    else:
+    quantiles = None
+    most_common = None
+    if not basic_stats:
         casting_function = (
             int if np.issubdtype(raster_band.dtype, np.integer) else float
         )


### PR DESCRIPTION
## Issue

Fixes #
- Story: https://app.shortcut.com/cartoteam/story/498660/singteloptus-errors-in-raster-uploads-using-connection-upload-raster
- Autolink: [sc-498660]

## Proposed Changes

Fix the `most_common` variable was not initialized for some cases.